### PR TITLE
Fix halved sample value for 16/24bit wav audio

### DIFF
--- a/wav/decode.go
+++ b/wav/decode.go
@@ -230,25 +230,25 @@ func (d *decoder) Stream(samples [][2]float64) (n int, ok bool) {
 		}
 	case d.h.BitsPerSample == 16 && d.h.NumChans == 1:
 		for i, j := 0, 0; i <= n-bytesPerFrame; i, j = i+bytesPerFrame, j+1 {
-			val := float64(int16(p[i+0])+int16(p[i+1])*(1<<8)) / (1<<16 - 1)
+			val := float64(int16(p[i+0])+int16(p[i+1])*(1<<8)) / (1<<15)
 			samples[j][0] = val
 			samples[j][1] = val
 		}
 	case d.h.BitsPerSample == 16 && d.h.NumChans >= 2:
 		for i, j := 0, 0; i <= n-bytesPerFrame; i, j = i+bytesPerFrame, j+1 {
-			samples[j][0] = float64(int16(p[i+0])+int16(p[i+1])*(1<<8)) / (1<<16 - 1)
-			samples[j][1] = float64(int16(p[i+2])+int16(p[i+3])*(1<<8)) / (1<<16 - 1)
+			samples[j][0] = float64(int16(p[i+0])+int16(p[i+1])*(1<<8)) / (1<<15)
+			samples[j][1] = float64(int16(p[i+2])+int16(p[i+3])*(1<<8)) / (1<<15)
 		}
 	case d.h.BitsPerSample == 24 && d.h.NumChans == 1:
 		for i, j := 0, 0; i <= n-bytesPerFrame; i, j = i+bytesPerFrame, j+1 {
-			val := float64((int32(p[i+0])<<8)+(int32(p[i+1])<<16)+(int32(p[i+2])<<24)) / (1 << 8) / (1<<24 - 1)
+			val := float64((int32(p[i+0])<<8)+(int32(p[i+1])<<16)+(int32(p[i+2])<<24)) / (1 << 8) / (1<<23)
 			samples[j][0] = val
 			samples[j][1] = val
 		}
 	case d.h.BitsPerSample == 24 && d.h.NumChans >= 2:
 		for i, j := 0, 0; i <= n-bytesPerFrame; i, j = i+bytesPerFrame, j+1 {
-			samples[j][0] = float64((int32(p[i+0])<<8)+(int32(p[i+1])<<16)+(int32(p[i+2])<<24)) / (1 << 8) / (1<<24 - 1)
-			samples[j][1] = float64((int32(p[i+3])<<8)+(int32(p[i+4])<<16)+(int32(p[i+5])<<24)) / (1 << 8) / (1<<24 - 1)
+			samples[j][0] = float64((int32(p[i+0])<<8)+(int32(p[i+1])<<16)+(int32(p[i+2])<<24)) / (1 << 8) / (1<<23)
+			samples[j][1] = float64((int32(p[i+3])<<8)+(int32(p[i+4])<<16)+(int32(p[i+5])<<24)) / (1 << 8) / (1<<23)
 		}
 	}
 	d.pos += int32(n)


### PR DESCRIPTION
The original code is mapping sample value of 16/24bit audio to [-0.5xxx,0.5].
This commit changes the range to [-1,1).
Fixes ikemen-engine/Ikemen-GO#1183